### PR TITLE
面談開始API作成

### DIFF
--- a/ai-api/app/infrastructure/vertex_chat_llm_client.py
+++ b/ai-api/app/infrastructure/vertex_chat_llm_client.py
@@ -1,5 +1,10 @@
+import json
 import os
+from typing import Type, Union, Dict, Any
+
 from langchain_google_vertexai import ChatVertexAI
+from langchain_core.pydantic_v1 import BaseModel
+
 from app.domain.chat import Message
 from app.services.gateways.chat_llm_client import ChatLLMClient
 from app.infrastructure.config import vertex_config
@@ -10,24 +15,42 @@ class VertexChatLLMClient(ChatLLMClient):
     
     def __init__(self):
          # LangChain の ChatVertexAI は初期化時に ADC を自動取得
-         self._llm = ChatVertexAI(
-             project=vertex_config.project_id,
-             location=vertex_config.location,
-             model=vertex_config.model_name,
-             temperature=float(os.getenv("TEMPERATURE", 0.7)),
-             max_output_tokens=int(os.getenv("MAX_TOKENS", 1024)),
-         )
-    
-    async def chat(self, messages: list[Message]) -> str:
+        self._base_llm = ChatVertexAI(
+            project=vertex_config.project_id,
+            location=vertex_config.location,
+            model=vertex_config.model_name,
+            temperature=float(os.getenv("TEMPERATURE", 0.7)),
+            max_output_tokens=int(os.getenv("MAX_TOKENS", 1024)),
+        )
+
+    async def chat(
+        self,
+        messages: list[Message],
+        schema: Union[Type[BaseModel], Dict[str, Any], None] = None,
+    ) -> Union[str, Dict[str, Any]]:
         """
-        Messageを配列で受け取り、メッセージを返す
+        - `schema` に Pydantic モデル or JSON Schema(dict) を渡すと JSON 構造で返す
+        - 渡さない場合は通常のテキストを返す
         """
-        # LangChain形式に変換
-        langchain_messages = []
-        for message in messages:
-            langchain_messages.append({
-                "role": message.role,
-                "content": message.content
-            })
-        response = await self._llm.ainvoke(langchain_messages)
-        return response.content
+        langchain_messages = [
+            {"role": m.role, "content": m.content} for m in messages
+        ]
+
+        # ① Pydantic モデル指定
+        if isinstance(schema, type) and issubclass(schema, BaseModel):
+            llm = self._base_llm.with_structured_output(schema)
+            res = await llm.ainvoke(langchain_messages)
+            return res.model_dump()
+
+        # ② dict(JSON Schema) 指定
+        if isinstance(schema, dict):
+            llm = self._base_llm.bind(
+                response_schema=schema,
+                response_mime_type="application/json",
+            )
+            res = await llm.ainvoke(langchain_messages)
+            return json.loads(res.content)
+
+        # ③ スキーマ無し（テキスト）
+        res = await self._base_llm.ainvoke(langchain_messages)
+        return res.content

--- a/ai-api/app/router.py
+++ b/ai-api/app/router.py
@@ -2,8 +2,10 @@
 
 from fastapi import APIRouter
 from app.services.llm_chat_service import LLMChatService
+from app.services.survey_service import SurveyService
 from app.infrastructure.vertex_chat_llm_client import VertexChatLLMClient
-from app.spec import ChatRequest, ChatResponse, HealthResponse
+from app.spec import ChatRequest, ChatResponse, HealthResponse, StartSurveyRequest, StartSurveyResponse, ChatMessageDto
+
 
 router = APIRouter()
 
@@ -33,3 +35,34 @@ async def chat_completion(request: ChatRequest):
     chat_service = LLMChatService(llm_client)
     result = await chat_service.invoke(request.messages, request.schema)
     return result
+
+
+@router.post("/start-survey", response_model=StartSurveyResponse)
+async def start_survey(request: StartSurveyRequest):
+    """
+    面談開始API
+
+    最新の健康状態データを基に、AIが面談開始のメッセージを生成します。
+    """
+    try:
+        # 依存関係をセットアップし、適切なサービスを呼び出す
+        llm_client = VertexChatLLMClient()
+        interview_service = SurveyService(llm_client)
+
+        # サービスを呼び出してビジネスロジックを実行
+        result = await interview_service.create_opening_message(request.health)
+
+        # サービスからの結果をHTTPレスポンスに変換する
+        if result.get("success"):
+            return StartSurveyResponse(
+                success=True,
+                opening_message=result.get("opening_message")
+            )
+        else:
+            return StartSurveyResponse(
+                success=False,
+                error=result.get("error")
+            )
+    except Exception as e:
+        # 予期せぬエラーが発生した場合のフォールバック
+        return StartSurveyResponse(success=False, error=f"サーバー内部でエラーが発生しました: {str(e)}")

--- a/ai-api/app/router.py
+++ b/ai-api/app/router.py
@@ -3,9 +3,7 @@
 from fastapi import APIRouter
 from app.services.llm_chat_service import LLMChatService
 from app.infrastructure.vertex_chat_llm_client import VertexChatLLMClient
-from app.spec import (
-    ChatRequest, ChatResponse, HealthResponse
-)
+from app.spec import ChatRequest, ChatResponse, HealthResponse
 
 router = APIRouter()
 
@@ -33,5 +31,5 @@ async def chat_completion(request: ChatRequest):
     llm_client = VertexChatLLMClient()
     # 依存性注入：インフラ層をアプリケーションサービスに注入
     chat_service = LLMChatService(llm_client)
-    result = await chat_service.invoke(request.messages)
+    result = await chat_service.invoke(request.messages, request.schema)
     return result

--- a/ai-api/app/services/gateways/chat_llm_client.py
+++ b/ai-api/app/services/gateways/chat_llm_client.py
@@ -1,5 +1,12 @@
-from typing import Protocol, List
+from typing import Protocol, List, Dict, Any, Union, Type
 from app.domain.chat import Message
+from langchain_core.pydantic_v1 import BaseModel
+
 
 class ChatLLMClient(Protocol):
-    async def chat(self, messages: List[Message]) -> str: ...
+    async def chat(
+        self,
+        messages: List[Message],
+        schema: Union[Type[BaseModel], Dict[str, Any], None] = None,
+    ) -> Union[str, Dict[str, Any]]:
+        ...

--- a/ai-api/app/services/llm_chat_service.py
+++ b/ai-api/app/services/llm_chat_service.py
@@ -1,4 +1,5 @@
-from typing import List
+from typing import List, Dict, Any, Optional
+
 from app.domain.chat import Chat, Message
 from app.services.gateways.chat_llm_client import ChatLLMClient
 from app.spec import ChatMessageDto
@@ -10,27 +11,29 @@ class LLMChatService:
     def __init__(self, llm_client: ChatLLMClient):
         self._llm_client = llm_client
 
-    async def invoke(self, messages: List[ChatMessageDto]) -> dict:
+    async def invoke(
+        self,
+        messages: List[ChatMessageDto],
+        schema: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
         """ユーザー入力を受け取り、LLM から応答を生成して返す"""
         if not messages:
             return {"success": False, "error": "メッセージが空です"}
-        
+
         try:
             # ドメインオブジェクトに変換
             chat = self._create_chat(messages)
             # AIチャット
-            generated_text = await self._llm_client.chat(chat.messages)              
+            generated = await self._llm_client.chat(chat.messages, schema=schema)
 
-            return {
-                "success": True,
-                "generated_text": generated_text
-            }
+            if isinstance(generated, dict):
+                return {"success": True, "generated_json": generated}
+            else:
+                return {"success": True, "generated_text": generated}
+
         except Exception as e:
-            return {
-                "success": False,
-                "error": str(e),
-            }
-    
-    def _create_chat(self, dtos: list[ChatMessageDto]) -> Chat:
-        """メッセージリストからChatドメインオブジェクトを作成"""
+            return {"success": False, "error": str(e)}
+
+    def _create_chat(self, dtos: List[ChatMessageDto]) -> Chat:
+        """メッセージリストから Chat ドメインオブジェクトを作成"""
         return Chat([Message(role=d.role, content=d.content) for d in dtos])

--- a/ai-api/app/services/survey_service.py
+++ b/ai-api/app/services/survey_service.py
@@ -1,0 +1,64 @@
+"""面談に関連するアプリケーションサービス"""
+
+from app.services.gateways.chat_llm_client import ChatLLMClient
+from app.domain.chat import Message
+from app.spec import HealthData
+
+
+class SurveyService:
+    """面談のユースケースを扱うサービス"""
+
+    def __init__(self, llm_client: ChatLLMClient):
+        """
+        Args:
+            llm_client: LLMと通信するためのゲートウェイインスタンス
+        """
+        self._llm_client = llm_client
+
+    async def create_opening_message(self, health_data: HealthData) -> dict:
+        """
+        健康状態のデータに基づいて、面談開始のメッセージを生成する
+
+        Args:
+            health_data: ユーザーから受け取った健康状態データ
+
+        Returns:
+            成功/失敗とメッセージまたはエラー情報を含む辞書
+        """
+        # プロンプトを構築する責務をこのサービスが担う
+        prompt_template = """
+        あなたは優秀なカウンセラーです。
+        以下の最新の健康状態のデータを参考に、相手を気遣い、自然な形で1on1面談を開始するための冒頭の挨拶を生成してください。
+
+        --- 最新の健康状態 ---
+        スコア: {score}ポイント(10ポイント中)
+        メモ: {note}
+        ---------------------
+
+        生成する挨拶の例:
+        「こんにちは！前回の面談のときより、ぐっすり眠れたみたいで安心しました。その後、調子はいかがですか？」
+        また、下記のルールを守ってください
+        - スコアについてはあなたが理解するための数字です。人間に「あなたのスコアはxxxです」とか言われてもしっくりこないので、具体的数字には触れないでください
+        - 顔色や声色については触れないですください。あなたはチャットボットカウンセラーなので、文字からしか感情を読み取れません。
+        """
+
+        prompt = prompt_template.format(
+            score=health_data.score,
+            note=health_data.note
+        )
+
+        # ドメインオブジェクトに変換してLLMに渡す
+        messages = [Message(role="user", content=prompt)]
+
+        try:
+            # ゲートウェイ（インフラ層）を呼び出してLLMからの応答を取得
+            generated_text = await self._llm_client.chat(messages, schema=None)
+
+            if isinstance(generated_text, str):
+                return {"success": True, "opening_message": generated_text.strip()}
+            else:
+                # LLMClientの実装によっては発生しうる
+                return {"success": False, "error": "LLMから予期しない形式の応答がありました。"}
+        except Exception as e:
+            # エラーログの記録をここに実装するとより良い
+            return {"success": False, "error": f"LLMとの通信でエラーが発生しました: {str(e)}"}

--- a/ai-api/app/spec.py
+++ b/ai-api/app/spec.py
@@ -51,3 +51,20 @@ class ChatResponse(BaseModel):
     generated_text: Optional[str] = Field(None, description="AIの返答")
     generated_json: Optional[dict] = None
     error: Optional[str] = Field(None, description="エラーメッセージ（失敗時のみ）")
+
+
+class HealthData(BaseModel):
+    """面談時の健康状態データ"""
+    score: int = Field(..., description="健康スコア（1-5）", example=5, ge=1, le=5)
+    note: str = Field(..., description="健康状態に関するメモ", example="前回よりぐっすり寝れたみたい。要経過観察")
+
+class StartSurveyRequest(BaseModel):
+    """面談開始リクエスト"""
+    health: HealthData = Field(..., description="最新の健康状態データ")
+    createdAt: str = Field(..., description="作成日", example="20250615")
+
+class StartSurveyResponse(BaseModel):
+    """面談開始レスポンス"""
+    success: bool = Field(..., description="処理の成功/失敗")
+    opening_message: Optional[str] = Field(None, description="AIが生成した面談開始のメッセージ")
+    error: Optional[str] = Field(None, description="エラーメッセージ（失敗時のみ）")

--- a/ai-api/app/spec.py
+++ b/ai-api/app/spec.py
@@ -32,10 +32,22 @@ class ChatRequest(BaseModel):
             {"role": "user", "content": "日本の首都はどこですか？"}
         ]
     )
+    schema: Optional[dict] = Field(
+    None,
+    description="JSON Schema（Draft-07 サブセット）。指定すると LLM がこの構造で返す",
+    example={
+            "type": "object",
+            "properties": {
+                "answer": { "type": "string" }
+            },
+            "required": ["answer"]
+        }
+    )
 
 
 class ChatResponse(BaseModel):
     """チャット会話レスポンス"""
     success: bool = Field(..., description="処理の成功/失敗")
     generated_text: Optional[str] = Field(None, description="AIの返答")
+    generated_json: Optional[dict] = None
     error: Optional[str] = Field(None, description="エラーメッセージ（失敗時のみ）")


### PR DESCRIPTION
# 概要
前回の面談サマリーを元に、面談開始時の文言を生成するAPIを作成しました

# 備考
本題とはずれますが、/chat APIについて、Optionalでschemaを渡したら指定通りのJSON schemaでレスポンスするように修正しました。
今度スコア集計APIを作る時にこれを使うつもりです。